### PR TITLE
Interfaces – OpenApiService Service Contract

### DIFF
--- a/tiferet_openapi/interfaces/__init__.py
+++ b/tiferet_openapi/interfaces/__init__.py
@@ -1,0 +1,6 @@
+'''Tiferet OpenAPI Service Interfaces'''
+
+# *** exports
+
+# ** app
+from .openapi import OpenApiService

--- a/tiferet_openapi/interfaces/openapi.py
+++ b/tiferet_openapi/interfaces/openapi.py
@@ -1,0 +1,61 @@
+'''Tiferet OpenAPI Service Interfaces'''
+
+# *** imports
+
+# ** core
+from abc import abstractmethod
+from typing import List
+
+# ** infra
+from tiferet import Service
+
+# ** app
+from ..domain import ApiRoute, ApiRouter
+
+
+# *** interfaces
+
+# ** interface: open_api_service
+class OpenApiService(Service):
+    '''
+    Abstract service contract for OpenAPI route and router retrieval.
+    '''
+
+    # * method: get_routers
+    @abstractmethod
+    def get_routers(self) -> List[ApiRouter]:
+        '''
+        Retrieve all configured API routers.
+
+        :return: A list of API routers.
+        :rtype: List[ApiRouter]
+        '''
+        raise NotImplementedError()
+
+    # * method: get_route
+    @abstractmethod
+    def get_route(self, route_id: str, router_name: str = None) -> ApiRoute:
+        '''
+        Retrieve a single API route by its identifier.
+
+        :param route_id: The unique identifier of the route.
+        :type route_id: str
+        :param router_name: Optional router name to scope the lookup.
+        :type router_name: str
+        :return: The matching API route.
+        :rtype: ApiRoute
+        '''
+        raise NotImplementedError()
+
+    # * method: get_status_code
+    @abstractmethod
+    def get_status_code(self, error_code: str) -> int:
+        '''
+        Retrieve the HTTP status code mapped to a given error code.
+
+        :param error_code: The error code to look up.
+        :type error_code: str
+        :return: The corresponding HTTP status code.
+        :rtype: int
+        '''
+        raise NotImplementedError()


### PR DESCRIPTION
## Summary

Implements the `OpenApiService` abstract service contract per issue #3.

### Changes
- **`tiferet_openapi/interfaces/openapi.py`** — `OpenApiService(Service)` with three abstract methods: `get_routers()`, `get_route()`, `get_status_code()`
- **`tiferet_openapi/interfaces/__init__.py`** — Public exports

### Acceptance Criteria
- `OpenApiService` extends `tiferet.interfaces.Service` ✅
- All three methods are abstract and raise `NotImplementedError` ✅
- Type hints reference `ApiRoute` and `ApiRouter` from the domain layer ✅
- Exports available from `tiferet_openapi.interfaces` ✅

Closes #3

---
[Warp conversation](https://app.warp.dev/conversation/a6846206-3cf8-4399-a783-93370dfba746)

Co-Authored-By: Oz <oz-agent@warp.dev>