### PR TITLE
Mappers – Aggregates and YAML TransferObjects

### DIFF
--- a/tiferet_openapi/mappers/__init__.py
+++ b/tiferet_openapi/mappers/__init__.py
@@ -1,0 +1,11 @@
+'''Tiferet OpenAPI Mapper Objects'''
+
+# *** exports
+
+# ** app
+from .openapi import (
+    ApiRouteAggregate,
+    ApiRouterAggregate,
+    ApiRouteYamlObject,
+    ApiRouterYamlObject,
+)

--- a/tiferet_openapi/mappers/openapi.py
+++ b/tiferet_openapi/mappers/openapi.py
@@ -1,0 +1,230 @@
+'''Tiferet OpenAPI Mapper Objects'''
+
+# *** imports
+
+# ** core
+from typing import Any, ClassVar, Dict, List
+
+# ** infra
+from pydantic import Field
+from tiferet import Aggregate, TransferObject
+
+# ** app
+from ..domain import ApiRoute, ApiRouter
+
+
+# *** mappers
+
+# ** mapper: api_route_aggregate
+class ApiRouteAggregate(ApiRoute, Aggregate):
+    '''
+    Aggregate for the ApiRoute domain object.
+    '''
+    pass
+
+
+# ** mapper: api_router_aggregate
+class ApiRouterAggregate(ApiRouter, Aggregate):
+    '''
+    Aggregate for the ApiRouter domain object.
+    '''
+
+    # * method: add_route
+    def add_route(self,
+            endpoint: str,
+            path: str,
+            methods: List[str],
+            status_code: int = 200,
+        ) -> ApiRouteAggregate:
+        '''
+        Add a new route to this router.
+
+        :param endpoint: The route endpoint identifier.
+        :type endpoint: str
+        :param path: The URL path.
+        :type path: str
+        :param methods: The HTTP methods.
+        :type methods: List[str]
+        :param status_code: The default HTTP status code.
+        :type status_code: int
+        :return: The created route aggregate.
+        :rtype: ApiRouteAggregate
+        '''
+
+        # Create the route with a fully-qualified endpoint.
+        route = ApiRouteAggregate(
+            id=endpoint,
+            endpoint=f'{self.name}.{endpoint}',
+            path=path,
+            methods=methods,
+            status_code=status_code,
+        )
+
+        # Append the route to the routes list.
+        routes = list(self.routes)
+        routes.append(route)
+        self.routes = routes
+
+        # Return the created route.
+        return route
+
+    # * method: remove_route
+    def remove_route(self, route_id: str) -> None:
+        '''
+        Remove a route from this router by its ID.
+
+        :param route_id: The route identifier to remove.
+        :type route_id: str
+        :return: None
+        :rtype: None
+        '''
+
+        # Filter out the route with the given ID.
+        self.routes = [r for r in self.routes if r.id != route_id]
+
+
+# ** mapper: api_route_yaml_object
+class ApiRouteYamlObject(ApiRoute, TransferObject):
+    '''
+    A YAML data representation of an API route.
+    '''
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {},
+        'to_data.yaml': {
+            'by_alias': True,
+            'exclude': {'id', 'endpoint'},
+        },
+    }
+
+    # * attribute: id
+    id: str | None = Field(
+        default=None,
+        description='The unique identifier of the route.',
+    )
+
+    # * attribute: endpoint
+    endpoint: str | None = Field(
+        default=None,
+        description='The fully-qualified endpoint (router_name.route_id).',
+    )
+
+    # * method: map
+    def map(self, id: str = None, endpoint: str = None, **overrides) -> ApiRouteAggregate:
+        '''
+        Map the route YAML data to a route aggregate.
+
+        :param id: The route identifier.
+        :type id: str
+        :param endpoint: The fully-qualified endpoint.
+        :type endpoint: str
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new route aggregate.
+        :rtype: ApiRouteAggregate
+        '''
+
+        # Map the route data with id and endpoint overrides.
+        return super().map(
+            ApiRouteAggregate,
+            id=id or self.id,
+            endpoint=endpoint or self.endpoint,
+            **overrides,
+        )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, route: ApiRoute, **overrides) -> 'ApiRouteYamlObject':
+        '''
+        Create an ApiRouteYamlObject from an ApiRoute model.
+
+        :param route: The route model.
+        :type route: ApiRoute
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new ApiRouteYamlObject.
+        :rtype: ApiRouteYamlObject
+        '''
+
+        # Create a new transfer object from the model.
+        return super().from_model(route, **overrides)
+
+
+# ** mapper: api_router_yaml_object
+class ApiRouterYamlObject(ApiRouter, TransferObject):
+    '''
+    A YAML data representation of an API router.
+    '''
+
+    # * attribute: _ROLES
+    _ROLES: ClassVar[Dict[str, Dict[str, Any]]] = {
+        'to_model': {'exclude': {'routes'}},
+        'to_data.yaml': {
+            'by_alias': True,
+            'exclude': {'name'},
+        },
+    }
+
+    # * attribute: name
+    name: str | None = Field(
+        default=None,
+        description='The name of the router.',
+    )
+
+    # * attribute: routes
+    routes: Dict[str, ApiRouteYamlObject] = Field(
+        default_factory=dict,
+        description='Routes in this router, keyed by route ID.',
+    )
+
+    # * method: map
+    def map(self, **overrides) -> ApiRouterAggregate:
+        '''
+        Map the router YAML data to a router aggregate.
+
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new router aggregate.
+        :rtype: ApiRouterAggregate
+        '''
+
+        # Convert dict routes to list with endpoint derivation.
+        router_name = overrides.get('name', self.name)
+        routes = [
+            route_obj.map(
+                id=route_id,
+                endpoint=f'{router_name}.{route_id}',
+            )
+            for route_id, route_obj in (self.routes or {}).items()
+        ]
+
+        # Map the router data with converted routes.
+        return super().map(
+            ApiRouterAggregate,
+            routes=routes,
+            **overrides,
+        )
+
+    # * method: from_model
+    @classmethod
+    def from_model(cls, router: ApiRouter, **overrides) -> 'ApiRouterYamlObject':
+        '''
+        Create an ApiRouterYamlObject from an ApiRouter model.
+
+        :param router: The router model.
+        :type router: ApiRouter
+        :param overrides: Additional keyword arguments.
+        :type overrides: dict
+        :return: A new ApiRouterYamlObject.
+        :rtype: ApiRouterYamlObject
+        '''
+
+        # Convert list routes to dict keyed by route ID.
+        routes = {
+            route.id: ApiRouteYamlObject.from_model(route)
+            for route in router.routes
+        }
+
+        # Create a new transfer object from the model.
+        return super().from_model(router, routes=routes, **overrides)

--- a/tiferet_openapi/mappers/tests/test_openapi.py
+++ b/tiferet_openapi/mappers/tests/test_openapi.py
@@ -1,0 +1,222 @@
+'''Tiferet OpenAPI Mapper Tests'''
+
+# *** imports
+
+# ** infra
+import pytest
+
+# ** app
+from ..openapi import (
+    ApiRouteAggregate,
+    ApiRouterAggregate,
+    ApiRouteYamlObject,
+    ApiRouterYamlObject,
+)
+
+
+# *** constants
+
+# ** constant: route_aggregate_data
+ROUTE_AGGREGATE_DATA = dict(
+    id='get_users',
+    endpoint='users.get_users',
+    path='/users',
+    methods=['GET'],
+    status_code=200,
+)
+
+# ** constant: router_aggregate_data
+ROUTER_AGGREGATE_DATA = dict(
+    name='users',
+    prefix='/api/v1',
+    routes=[],
+)
+
+# ** constant: route_yaml_data
+ROUTE_YAML_DATA = dict(
+    path='/users',
+    methods=['GET'],
+    status_code=200,
+)
+
+# ** constant: router_yaml_data
+ROUTER_YAML_DATA = dict(
+    prefix='/api/v1',
+    routes={
+        'get_users': ROUTE_YAML_DATA,
+    },
+)
+
+
+# *** fixtures
+
+# ** fixture: route_aggregate
+@pytest.fixture
+def route_aggregate() -> ApiRouteAggregate:
+    '''
+    A sample ApiRouteAggregate instance.
+
+    :return: An ApiRouteAggregate instance.
+    :rtype: ApiRouteAggregate
+    '''
+
+    return ApiRouteAggregate(**ROUTE_AGGREGATE_DATA)
+
+
+# ** fixture: router_aggregate
+@pytest.fixture
+def router_aggregate() -> ApiRouterAggregate:
+    '''
+    A sample ApiRouterAggregate instance with no routes.
+
+    :return: An ApiRouterAggregate instance.
+    :rtype: ApiRouterAggregate
+    '''
+
+    return ApiRouterAggregate(**ROUTER_AGGREGATE_DATA)
+
+
+# *** tests
+
+# ** test: api_route_aggregate_constructor
+def test_api_route_aggregate_constructor(route_aggregate: ApiRouteAggregate) -> None:
+    '''
+    Test that ApiRouteAggregate can be instantiated with all fields.
+
+    :param route_aggregate: The sample route aggregate.
+    :type route_aggregate: ApiRouteAggregate
+    '''
+
+    # Verify all fields match the provided data.
+    assert route_aggregate.id == ROUTE_AGGREGATE_DATA['id']
+    assert route_aggregate.endpoint == ROUTE_AGGREGATE_DATA['endpoint']
+    assert route_aggregate.path == ROUTE_AGGREGATE_DATA['path']
+    assert route_aggregate.methods == ROUTE_AGGREGATE_DATA['methods']
+    assert route_aggregate.status_code == ROUTE_AGGREGATE_DATA['status_code']
+
+
+# ** test: api_router_aggregate_add_route
+def test_api_router_aggregate_add_route(router_aggregate: ApiRouterAggregate) -> None:
+    '''
+    Test that add_route creates a route with the correct fully-qualified endpoint.
+
+    :param router_aggregate: The sample router aggregate.
+    :type router_aggregate: ApiRouterAggregate
+    '''
+
+    # Add a route to the router.
+    route = router_aggregate.add_route(
+        endpoint='get_users',
+        path='/users',
+        methods=['GET'],
+    )
+
+    # Verify the route was added with the correct endpoint.
+    assert len(router_aggregate.routes) == 1
+    assert route.id == 'get_users'
+    assert route.endpoint == 'users.get_users'
+    assert route.path == '/users'
+    assert route.methods == ['GET']
+    assert route.status_code == 200
+
+
+# ** test: api_router_aggregate_remove_route
+def test_api_router_aggregate_remove_route(router_aggregate: ApiRouterAggregate) -> None:
+    '''
+    Test that remove_route removes the route by ID.
+
+    :param router_aggregate: The sample router aggregate.
+    :type router_aggregate: ApiRouterAggregate
+    '''
+
+    # Add a route, then remove it.
+    router_aggregate.add_route(endpoint='get_users', path='/users', methods=['GET'])
+    assert len(router_aggregate.routes) == 1
+
+    # Remove the route.
+    router_aggregate.remove_route('get_users')
+
+    # Verify the route was removed.
+    assert len(router_aggregate.routes) == 0
+
+
+# ** test: api_route_yaml_object_map
+def test_api_route_yaml_object_map() -> None:
+    '''
+    Test that ApiRouteYamlObject.map() produces a valid ApiRouteAggregate.
+    '''
+
+    # Create a route YAML object and map it.
+    yaml_obj = ApiRouteYamlObject.model_validate(ROUTE_YAML_DATA)
+    aggregate = yaml_obj.map(id='get_users', endpoint='users.get_users')
+
+    # Verify the aggregate has the correct fields.
+    assert isinstance(aggregate, ApiRouteAggregate)
+    assert aggregate.id == 'get_users'
+    assert aggregate.endpoint == 'users.get_users'
+    assert aggregate.path == '/users'
+    assert aggregate.methods == ['GET']
+    assert aggregate.status_code == 200
+
+
+# ** test: api_router_yaml_object_map
+def test_api_router_yaml_object_map() -> None:
+    '''
+    Test that ApiRouterYamlObject.map() produces a valid ApiRouterAggregate with nested routes.
+    '''
+
+    # Create a router YAML object and map it.
+    yaml_obj = ApiRouterYamlObject.model_validate(ROUTER_YAML_DATA)
+    aggregate = yaml_obj.map(name='users')
+
+    # Verify the aggregate has the correct fields.
+    assert isinstance(aggregate, ApiRouterAggregate)
+    assert aggregate.name == 'users'
+    assert aggregate.prefix == '/api/v1'
+    assert len(aggregate.routes) == 1
+    assert aggregate.routes[0].id == 'get_users'
+    assert aggregate.routes[0].endpoint == 'users.get_users'
+
+
+# ** test: api_route_from_model_round_trip
+def test_api_route_from_model_round_trip(route_aggregate: ApiRouteAggregate) -> None:
+    '''
+    Test that from_model round-trips correctly for ApiRoute.
+
+    :param route_aggregate: The sample route aggregate.
+    :type route_aggregate: ApiRouteAggregate
+    '''
+
+    # Convert aggregate to YAML object and back.
+    yaml_obj = ApiRouteYamlObject.from_model(route_aggregate)
+    result = yaml_obj.map()
+
+    # Verify the round-trip preserves data.
+    assert result.id == route_aggregate.id
+    assert result.endpoint == route_aggregate.endpoint
+    assert result.path == route_aggregate.path
+    assert result.methods == route_aggregate.methods
+    assert result.status_code == route_aggregate.status_code
+
+
+# ** test: api_router_from_model_round_trip
+def test_api_router_from_model_round_trip() -> None:
+    '''
+    Test that from_model round-trips correctly for ApiRouter.
+    '''
+
+    # Build a router aggregate with a route.
+    router = ApiRouterAggregate(**ROUTER_AGGREGATE_DATA)
+    router.add_route(endpoint='get_users', path='/users', methods=['GET'])
+
+    # Convert to YAML object and back.
+    yaml_obj = ApiRouterYamlObject.from_model(router)
+    result = yaml_obj.map(name='users')
+
+    # Verify the round-trip preserves data.
+    assert result.name == router.name
+    assert result.prefix == router.prefix
+    assert len(result.routes) == 1
+    assert result.routes[0].id == 'get_users'
+    assert result.routes[0].endpoint == 'users.get_users'
+    assert result.routes[0].path == '/users'


### PR DESCRIPTION
## Summary

Implements the mapper layer for tiferet-openapi per issue #4.

### Changes
- **`tiferet_openapi/mappers/openapi.py`** — Four mapper classes:
  - `ApiRouteAggregate` — pass-through aggregate
  - `ApiRouterAggregate` — `add_route()` and `remove_route()` mutations
  - `ApiRouteYamlObject` — YAML serialization with `_ROLES`, `map()`, `from_model()`
  - `ApiRouterYamlObject` — nested dict→list route conversion in `map()`, list→dict in `from_model()`
- **`tiferet_openapi/mappers/__init__.py`** — Public exports
- **`tiferet_openapi/mappers/tests/test_openapi.py`** — 7 tests

### Acceptance Criteria
- `ApiRouterAggregate.add_route()` creates route with correct fully-qualified endpoint ✅
- `ApiRouterAggregate.remove_route()` removes route by ID ✅
- `ApiRouteYamlObject.map()` produces valid `ApiRouteAggregate` ✅
- `ApiRouterYamlObject.map()` produces valid `ApiRouterAggregate` with nested routes ✅
- `from_model()` round-trips correctly for both route and router ✅
- All tests pass ✅

Closes #4

---
[Warp conversation](https://app.warp.dev/conversation/a6846206-3cf8-4399-a783-93370dfba746)

Co-Authored-By: Oz <oz-agent@warp.dev>