### PR TITLE
Repos – OpenApiYamlRepository (#6)

### DIFF
--- a/tiferet_openapi/repos/__init__.py
+++ b/tiferet_openapi/repos/__init__.py
@@ -1,0 +1,6 @@
+'''Tiferet OpenAPI Repositories'''
+
+# *** exports
+
+# ** app
+from .openapi import OpenApiYamlRepository

--- a/tiferet_openapi/repos/openapi.py
+++ b/tiferet_openapi/repos/openapi.py
@@ -1,0 +1,129 @@
+'''Tiferet OpenAPI YAML Repository'''
+
+# *** imports
+
+# ** core
+from typing import List
+
+# ** infra
+from tiferet import Yaml
+
+# ** app
+from ..interfaces import OpenApiService
+from ..domain import ApiRoute, ApiRouter
+from ..mappers import (
+    ApiRouterAggregate,
+    ApiRouterYamlObject,
+)
+
+
+# *** repos
+
+# ** repo: open_api_yaml_repository
+class OpenApiYamlRepository(OpenApiService):
+    '''
+    YAML-backed repository for OpenAPI router and error-to-status-code configurations.
+    '''
+
+    # * attribute: openapi_yaml_file
+    openapi_yaml_file: str
+
+    # * attribute: encoding
+    encoding: str
+
+    # * attribute: root_key
+    root_key: str
+
+    # * init
+    def __init__(self, openapi_yaml_file: str, root_key: str = 'openapi', encoding: str = 'utf-8') -> None:
+        '''
+        Initialize the OpenAPI YAML repository.
+
+        :param openapi_yaml_file: The YAML configuration file path.
+        :type openapi_yaml_file: str
+        :param root_key: The root key in the YAML file (e.g. 'openapi', 'flask', 'fast').
+        :type root_key: str
+        :param encoding: The file encoding (default is 'utf-8').
+        :type encoding: str
+        '''
+
+        # Set the repository attributes.
+        self.openapi_yaml_file = openapi_yaml_file
+        self.encoding = encoding
+        self.root_key = root_key
+
+    # * method: get_routers
+    def get_routers(self) -> List[ApiRouterAggregate]:
+        '''
+        Retrieve all configured API routers from the YAML file.
+
+        :return: A list of API router aggregates.
+        :rtype: List[ApiRouterAggregate]
+        '''
+
+        # Load the routers mapping from the configuration file.
+        routers_data = Yaml(
+            self.openapi_yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get(self.root_key, {}).get('routers', {})
+        )
+
+        # Map each entry via ApiRouterYamlObject and return the list.
+        return [
+            ApiRouterYamlObject.model_validate(
+                dict(name=name, **data)
+            ).map()
+            for name, data in routers_data.items()
+        ]
+
+    # * method: get_route
+    def get_route(self, route_id: str, router_name: str = None) -> ApiRoute | None:
+        '''
+        Retrieve a single API route by its identifier.
+
+        :param route_id: The unique identifier of the route.
+        :type route_id: str
+        :param router_name: Optional router name to scope the lookup.
+        :type router_name: str
+        :return: The matching API route, or None if not found.
+        :rtype: ApiRoute | None
+        '''
+
+        # Load all routers.
+        routers = self.get_routers()
+
+        # Iterate over routers, filtering by router_name if provided.
+        for router in routers:
+            if router_name and router.name != router_name:
+                continue
+
+            # Search for the route within this router.
+            for route in router.routes:
+                if route.id == route_id:
+                    return route
+
+        # Return None if no matching route was found.
+        return None
+
+    # * method: get_status_code
+    def get_status_code(self, error_code: str) -> int:
+        '''
+        Retrieve the HTTP status code mapped to a given error code.
+
+        :param error_code: The error code to look up.
+        :type error_code: str
+        :return: The corresponding HTTP status code, defaulting to 500.
+        :rtype: int
+        '''
+
+        # Load the errors mapping from the configuration file.
+        errors_data = Yaml(
+            self.openapi_yaml_file,
+            encoding=self.encoding,
+        ).load(
+            start_node=lambda data: data.get(self.root_key, {}).get('errors', {})
+        )
+
+        # Return the mapped status code, defaulting to 500.
+        return errors_data.get(error_code, 500)

--- a/tiferet_openapi/repos/tests/test_openapi.py
+++ b/tiferet_openapi/repos/tests/test_openapi.py
@@ -1,0 +1,311 @@
+'''Tiferet OpenAPI YAML Repository Tests'''
+
+# *** imports
+
+# ** core
+from pathlib import Path
+
+# ** infra
+import pytest
+
+# ** app
+from ..openapi import OpenApiYamlRepository
+
+
+# *** constants
+
+# ** constant: openapi_yaml_content
+OPENAPI_YAML_CONTENT = """\
+openapi:
+  routers:
+    calc:
+      prefix: /calc
+      routes:
+        add:
+          path: /add
+          methods:
+            - POST
+          status_code: 200
+        subtract:
+          path: /subtract
+          methods:
+            - POST
+          status_code: 200
+    health:
+      routes:
+        ping:
+          path: /ping
+          methods:
+            - GET
+          status_code: 200
+  errors:
+    INVALID_INPUT: 400
+    DIVISION_BY_ZERO: 422
+    NOT_FOUND: 404
+"""
+
+# ** constant: fast_yaml_content
+FAST_YAML_CONTENT = """\
+fast:
+  routers:
+    api:
+      prefix: /api
+      routes:
+        list_items:
+          path: /items
+          methods:
+            - GET
+          status_code: 200
+  errors:
+    UNAUTHORIZED: 401
+"""
+
+
+# *** fixtures
+
+# ** fixture: openapi_yaml_file
+@pytest.fixture
+def openapi_yaml_file(tmp_path: Path) -> Path:
+    '''
+    Create a temporary openapi.yml file for testing.
+
+    :param tmp_path: The temporary directory path.
+    :type tmp_path: Path
+    :return: Path to the temporary YAML file.
+    :rtype: Path
+    '''
+
+    # Write the YAML content to a temporary file.
+    file_path = tmp_path / 'openapi.yml'
+    file_path.write_text(OPENAPI_YAML_CONTENT, encoding='utf-8')
+    return file_path
+
+
+# ** fixture: fast_yaml_file
+@pytest.fixture
+def fast_yaml_file(tmp_path: Path) -> Path:
+    '''
+    Create a temporary fast.yml file for testing.
+
+    :param tmp_path: The temporary directory path.
+    :type tmp_path: Path
+    :return: Path to the temporary YAML file.
+    :rtype: Path
+    '''
+
+    # Write the YAML content to a temporary file.
+    file_path = tmp_path / 'fast.yml'
+    file_path.write_text(FAST_YAML_CONTENT, encoding='utf-8')
+    return file_path
+
+
+# ** fixture: repo
+@pytest.fixture
+def repo(openapi_yaml_file: Path) -> OpenApiYamlRepository:
+    '''
+    Create an OpenApiYamlRepository with default root_key.
+
+    :param openapi_yaml_file: Path to the temporary YAML file.
+    :type openapi_yaml_file: Path
+    :return: The repository instance.
+    :rtype: OpenApiYamlRepository
+    '''
+
+    # Return a repository instance with the default root key.
+    return OpenApiYamlRepository(
+        openapi_yaml_file=str(openapi_yaml_file),
+    )
+
+
+# ** fixture: fast_repo
+@pytest.fixture
+def fast_repo(fast_yaml_file: Path) -> OpenApiYamlRepository:
+    '''
+    Create an OpenApiYamlRepository with root_key='fast'.
+
+    :param fast_yaml_file: Path to the temporary YAML file.
+    :type fast_yaml_file: Path
+    :return: The repository instance.
+    :rtype: OpenApiYamlRepository
+    '''
+
+    # Return a repository instance with the 'fast' root key.
+    return OpenApiYamlRepository(
+        openapi_yaml_file=str(fast_yaml_file),
+        root_key='fast',
+    )
+
+
+# *** tests
+
+# ** test: get_routers_default_root_key
+def test_get_routers_default_root_key(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_routers loads and maps routers with the default 'openapi' root key.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve all routers.
+    routers = repo.get_routers()
+
+    # Assert two routers were loaded.
+    assert len(routers) == 2
+
+    # Assert router names.
+    router_names = [r.name for r in routers]
+    assert 'calc' in router_names
+    assert 'health' in router_names
+
+    # Assert calc router details.
+    calc_router = next(r for r in routers if r.name == 'calc')
+    assert calc_router.prefix == '/calc'
+    assert len(calc_router.routes) == 2
+
+    # Assert route details.
+    add_route = next(r for r in calc_router.routes if r.id == 'add')
+    assert add_route.endpoint == 'calc.add'
+    assert add_route.path == '/add'
+    assert add_route.methods == ['POST']
+    assert add_route.status_code == 200
+
+
+# ** test: get_routers_alternate_root_key
+def test_get_routers_alternate_root_key(fast_repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_routers works with root_key='fast'.
+
+    :param fast_repo: The repository instance with fast root key.
+    :type fast_repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve all routers.
+    routers = fast_repo.get_routers()
+
+    # Assert one router was loaded.
+    assert len(routers) == 1
+    assert routers[0].name == 'api'
+    assert routers[0].prefix == '/api'
+
+    # Assert route details.
+    assert len(routers[0].routes) == 1
+    assert routers[0].routes[0].id == 'list_items'
+    assert routers[0].routes[0].endpoint == 'api.list_items'
+
+
+# ** test: get_route_found
+def test_get_route_found(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_route returns the correct route when found.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve a specific route.
+    route = repo.get_route('add')
+
+    # Assert the route was found.
+    assert route is not None
+    assert route.id == 'add'
+    assert route.endpoint == 'calc.add'
+    assert route.path == '/add'
+
+
+# ** test: get_route_not_found
+def test_get_route_not_found(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_route returns None when the route is not found.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve a non-existent route.
+    route = repo.get_route('nonexistent')
+
+    # Assert None was returned.
+    assert route is None
+
+
+# ** test: get_route_filtered_by_router_name
+def test_get_route_filtered_by_router_name(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_route filters by router_name when provided.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve a route scoped to the 'calc' router.
+    route = repo.get_route('add', router_name='calc')
+    assert route is not None
+    assert route.endpoint == 'calc.add'
+
+    # Attempt to retrieve 'add' from the 'health' router (should not exist).
+    route = repo.get_route('add', router_name='health')
+    assert route is None
+
+
+# ** test: get_route_filtered_by_wrong_router_name
+def test_get_route_filtered_by_wrong_router_name(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_route returns None when router_name does not match.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Retrieve 'ping' from the 'calc' router (should not exist there).
+    route = repo.get_route('ping', router_name='calc')
+    assert route is None
+
+    # Retrieve 'ping' from the correct 'health' router.
+    route = repo.get_route('ping', router_name='health')
+    assert route is not None
+    assert route.endpoint == 'health.ping'
+
+
+# ** test: get_status_code_mapped
+def test_get_status_code_mapped(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_status_code returns the mapped status code.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Assert mapped error codes return the correct status.
+    assert repo.get_status_code('INVALID_INPUT') == 400
+    assert repo.get_status_code('DIVISION_BY_ZERO') == 422
+    assert repo.get_status_code('NOT_FOUND') == 404
+
+
+# ** test: get_status_code_default
+def test_get_status_code_default(repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_status_code returns 500 for unknown error codes.
+
+    :param repo: The repository instance.
+    :type repo: OpenApiYamlRepository
+    '''
+
+    # Assert unknown error codes default to 500.
+    assert repo.get_status_code('UNKNOWN_ERROR') == 500
+
+
+# ** test: get_status_code_alternate_root_key
+def test_get_status_code_alternate_root_key(fast_repo: OpenApiYamlRepository) -> None:
+    '''
+    Test that get_status_code works with an alternate root key.
+
+    :param fast_repo: The repository instance with fast root key.
+    :type fast_repo: OpenApiYamlRepository
+    '''
+
+    # Assert mapped error code from the fast config.
+    assert fast_repo.get_status_code('UNAUTHORIZED') == 401
+
+    # Assert unknown error codes still default to 500.
+    assert fast_repo.get_status_code('UNKNOWN') == 500


### PR DESCRIPTION
## Summary

Implements `OpenApiYamlRepository(OpenApiService)` — a YAML-backed repository for OpenAPI router and error-to-status-code configurations.

### Changes
- **`tiferet_openapi/repos/openapi.py`** — New repository with parameterized `root_key` (supports `openapi`, `flask`, `fast` YAML formats), `get_routers()`, `get_route()`, and `get_status_code()`.
- **`tiferet_openapi/repos/__init__.py`** — Public export.
- **`tiferet_openapi/repos/tests/test_openapi.py`** — 9 integration tests with `tmp_path` YAML fixtures covering all acceptance criteria.

Closes #6

---
[Warp conversation](https://app.warp.dev/conversation/029e3b7e-e37e-4d09-8676-7e692cc2aa01)

Co-Authored-By: Oz <oz-agent@warp.dev>