### PR TITLE
Contexts – OpenApiContext and OpenApiRequestContext (#7)

### DIFF
--- a/tiferet_openapi/contexts/__init__.py
+++ b/tiferet_openapi/contexts/__init__.py
@@ -1,0 +1,7 @@
+'''Tiferet OpenAPI Contexts'''
+
+# *** exports
+
+# ** app
+from .openapi import OpenApiContext
+from .request import OpenApiRequestContext

--- a/tiferet_openapi/contexts/openapi.py
+++ b/tiferet_openapi/contexts/openapi.py
@@ -1,0 +1,140 @@
+'''Tiferet OpenAPI Context'''
+
+# *** imports
+
+# ** core
+from typing import Any, Callable
+
+# ** infra
+from tiferet import TiferetError
+from tiferet.assets.exceptions import TiferetAPIError
+from tiferet.contexts import (
+    AppInterfaceContext,
+    FeatureContext,
+    ErrorContext,
+    LoggingContext,
+)
+from tiferet.events import DomainEvent
+
+# ** app
+from .request import OpenApiRequestContext
+
+
+# *** contexts
+
+# ** context: open_api_context
+class OpenApiContext(AppInterfaceContext):
+    '''
+    A shared API context for managing OpenAPI interactions within the Tiferet framework.
+    '''
+
+    # * attribute: get_route_handler
+    get_route_handler: Callable
+
+    # * attribute: get_status_code_handler
+    get_status_code_handler: Callable
+
+    # * init
+    def __init__(self,
+            interface_id: str,
+            features: FeatureContext,
+            errors: ErrorContext,
+            logging: LoggingContext,
+            get_route_evt: DomainEvent,
+            get_status_code_evt: DomainEvent,
+        ):
+        '''
+        Initialize the OpenAPI context.
+
+        :param interface_id: The interface ID.
+        :type interface_id: str
+        :param features: The feature context.
+        :type features: FeatureContext
+        :param errors: The error context.
+        :type errors: ErrorContext
+        :param logging: The logging context.
+        :type logging: LoggingContext
+        :param get_route_evt: The domain event for retrieving a route.
+        :type get_route_evt: DomainEvent
+        :param get_status_code_evt: The domain event for retrieving a status code.
+        :type get_status_code_evt: DomainEvent
+        '''
+
+        # Call the parent constructor.
+        super().__init__(interface_id, features, errors, logging)
+
+        # Set the domain event handlers.
+        self.get_route_handler = get_route_evt.execute
+        self.get_status_code_handler = get_status_code_evt.execute
+
+    # * method: parse_request
+    def parse_request(self, headers: dict = {}, data: dict = {}, feature_id: str = None, **kwargs) -> OpenApiRequestContext:
+        '''
+        Parse the incoming request and return an OpenApiRequestContext instance.
+
+        :param headers: The request headers.
+        :type headers: dict
+        :param data: The request data.
+        :type data: dict
+        :param feature_id: The feature ID.
+        :type feature_id: str
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: An OpenApiRequestContext instance.
+        :rtype: OpenApiRequestContext
+        '''
+
+        # Return an OpenApiRequestContext instance.
+        return OpenApiRequestContext(
+            headers=headers,
+            data=data,
+            feature_id=feature_id,
+        )
+
+    # * method: handle_error
+    def handle_error(self, error: Exception, **kwargs) -> Any:
+        '''
+        Handle the error and raise TiferetAPIError with status_code.
+
+        :param error: The error to handle.
+        :type error: Exception
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The error response.
+        :rtype: Any
+        '''
+
+        # Get the status code via event if it's a TiferetError.
+        if isinstance(error, TiferetError):
+            status_code = self.get_status_code_handler(error_code=error.error_code)
+        else:
+            status_code = 500
+
+        # Delegate formatting to parent (which raises TiferetAPIError).
+        try:
+            return super().handle_error(error, **kwargs)
+        except TiferetAPIError as api_error:
+            api_error.status_code = status_code
+            raise
+
+    # * method: handle_response
+    def handle_response(self, request: OpenApiRequestContext, **kwargs) -> Any:
+        '''
+        Handle the response from the request context.
+
+        :param request: The request context.
+        :type request: OpenApiRequestContext
+        :param kwargs: Additional keyword arguments.
+        :type kwargs: dict
+        :return: The response and status code.
+        :rtype: Any
+        '''
+
+        # Handle the response from the request context.
+        response = super().handle_response(request, **kwargs)
+
+        # Retrieve the route by the request feature id.
+        route = self.get_route_handler(endpoint=request.feature_id)
+
+        # Return the result with the specified status code.
+        return response, route.status_code if route else 200

--- a/tiferet_openapi/contexts/request.py
+++ b/tiferet_openapi/contexts/request.py
@@ -1,0 +1,72 @@
+'''Tiferet OpenAPI Request Context'''
+
+# *** imports
+
+# ** core
+from typing import Any
+
+# ** infra
+from pydantic import BaseModel
+from tiferet.contexts.request import RequestContext
+
+
+# *** contexts
+
+# ** context: open_api_request_context
+class OpenApiRequestContext(RequestContext):
+    '''
+    A context for handling OpenAPI request data and responses with Pydantic model serialization.
+    '''
+
+    # * method: handle_response
+    def handle_response(self) -> Any:
+        '''
+        Handle the response for the OpenAPI request context.
+
+        :return: The response.
+        :rtype: Any
+        '''
+
+        # Set the result using the set_result method to ensure proper formatting.
+        self.set_result(self.result)
+
+        # Handle the response using the parent method.
+        return super().handle_response()
+
+    # * method: set_result
+    def set_result(self, result: Any, data_key: str = None):
+        '''
+        Set the result of the request context.
+
+        :param result: The result to set.
+        :type result: Any
+        :param data_key: The key in the request data to set the result to.
+            If provided, the raw result is stored for downstream commands.
+            If None, the result is serialized for the final response.
+        :type data_key: str
+        '''
+
+        # If a data key is provided, delegate to the parent to store the raw result.
+        if data_key:
+            super().set_result(result, data_key=data_key)
+            return
+
+        # If the response is None, return an empty response.
+        if result is None:
+            self.result = ''
+
+        # Convert the response to a dictionary if it's a BaseModel.
+        elif isinstance(result, BaseModel):
+            self.result = result.model_dump()
+
+        # If the response is a list containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, list) and all(isinstance(item, BaseModel) for item in result):
+            self.result = [item.model_dump() for item in result]
+
+        # If the response is a dict containing BaseModel instances, convert each to a dictionary.
+        elif isinstance(result, dict) and all(isinstance(value, BaseModel) for value in result.values()):
+            self.result = {key: value.model_dump() for key, value in result.items()}
+
+        # Otherwise, set the result directly.
+        else:
+            self.result = result

--- a/tiferet_openapi/contexts/tests/test_openapi.py
+++ b/tiferet_openapi/contexts/tests/test_openapi.py
@@ -1,0 +1,377 @@
+'''Tiferet OpenAPI Context Tests'''
+
+# *** imports
+
+# ** core
+from typing import Any
+from unittest import mock
+
+# ** infra
+import pytest
+from pydantic import BaseModel, Field
+from tiferet import TiferetError
+from tiferet.assets.exceptions import TiferetAPIError
+from tiferet.contexts import FeatureContext, ErrorContext, LoggingContext
+from tiferet.events import DomainEvent
+
+# ** app
+from ..openapi import OpenApiContext
+from ..request import OpenApiRequestContext
+
+
+# *** models
+
+# ** model: sample_model
+class SampleModel(BaseModel):
+    '''
+    A sample Pydantic model for testing serialization.
+    '''
+
+    # * attribute: name
+    name: str = Field(..., description='The name.')
+
+    # * attribute: value
+    value: int = Field(..., description='The value.')
+
+
+# *** fixtures
+
+# ** fixture: mock_features
+@pytest.fixture
+def mock_features() -> FeatureContext:
+    '''
+    Mock FeatureContext for testing.
+
+    :return: A mock FeatureContext.
+    :rtype: FeatureContext
+    '''
+    return mock.Mock(spec=FeatureContext)
+
+
+# ** fixture: mock_errors
+@pytest.fixture
+def mock_errors() -> ErrorContext:
+    '''
+    Mock ErrorContext for testing.
+
+    :return: A mock ErrorContext.
+    :rtype: ErrorContext
+    '''
+    return mock.Mock(spec=ErrorContext)
+
+
+# ** fixture: mock_logging
+@pytest.fixture
+def mock_logging() -> LoggingContext:
+    '''
+    Mock LoggingContext for testing.
+
+    :return: A mock LoggingContext.
+    :rtype: LoggingContext
+    '''
+    return mock.Mock(spec=LoggingContext)
+
+
+# ** fixture: mock_get_route_evt
+@pytest.fixture
+def mock_get_route_evt() -> DomainEvent:
+    '''
+    Mock domain event for get_route.
+
+    :return: A mock DomainEvent with an execute method.
+    :rtype: DomainEvent
+    '''
+    evt = mock.Mock(spec=DomainEvent)
+    evt.execute = mock.Mock()
+    return evt
+
+
+# ** fixture: mock_get_status_code_evt
+@pytest.fixture
+def mock_get_status_code_evt() -> DomainEvent:
+    '''
+    Mock domain event for get_status_code.
+
+    :return: A mock DomainEvent with an execute method.
+    :rtype: DomainEvent
+    '''
+    evt = mock.Mock(spec=DomainEvent)
+    evt.execute = mock.Mock()
+    return evt
+
+
+# ** fixture: context
+@pytest.fixture
+def context(
+        mock_features: FeatureContext,
+        mock_errors: ErrorContext,
+        mock_logging: LoggingContext,
+        mock_get_route_evt: DomainEvent,
+        mock_get_status_code_evt: DomainEvent,
+    ) -> OpenApiContext:
+    '''
+    Create an OpenApiContext for testing.
+
+    :param mock_features: The mock feature context.
+    :type mock_features: FeatureContext
+    :param mock_errors: The mock error context.
+    :type mock_errors: ErrorContext
+    :param mock_logging: The mock logging context.
+    :type mock_logging: LoggingContext
+    :param mock_get_route_evt: The mock get_route domain event.
+    :type mock_get_route_evt: DomainEvent
+    :param mock_get_status_code_evt: The mock get_status_code domain event.
+    :type mock_get_status_code_evt: DomainEvent
+    :return: The OpenApiContext instance.
+    :rtype: OpenApiContext
+    '''
+
+    return OpenApiContext(
+        interface_id='test_api',
+        features=mock_features,
+        errors=mock_errors,
+        logging=mock_logging,
+        get_route_evt=mock_get_route_evt,
+        get_status_code_evt=mock_get_status_code_evt,
+    )
+
+
+# *** tests
+
+# ** test: parse_request_returns_openapi_request_context
+def test_parse_request_returns_openapi_request_context(context: OpenApiContext) -> None:
+    '''
+    Test that parse_request returns an OpenApiRequestContext instance.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    '''
+
+    # Parse a request.
+    request = context.parse_request(
+        headers={'content-type': 'application/json'},
+        data={'a': 1, 'b': 2},
+        feature_id='calc.add',
+    )
+
+    # Assert the result is an OpenApiRequestContext.
+    assert isinstance(request, OpenApiRequestContext)
+    assert request.feature_id == 'calc.add'
+    assert request.data == {'a': 1, 'b': 2}
+
+
+# ** test: handle_error_tiferet_error_status_code
+def test_handle_error_tiferet_error_status_code(
+        context: OpenApiContext,
+        mock_get_status_code_evt: DomainEvent,
+        mock_errors: ErrorContext,
+    ) -> None:
+    '''
+    Test that handle_error resolves status code via get_status_code_handler for TiferetError.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_status_code_evt: The mock get_status_code domain event.
+    :type mock_get_status_code_evt: DomainEvent
+    :param mock_errors: The mock error context.
+    :type mock_errors: ErrorContext
+    '''
+
+    # Configure the mock to return 400 status code.
+    mock_get_status_code_evt.execute.return_value = 400
+
+    # Configure ErrorContext.handle_error to return a formatted error dict.
+    mock_errors.handle_error.return_value = dict(
+        name='Invalid Input',
+        message='Value must be a number',
+        error_code='INVALID_INPUT',
+    )
+
+    # Create a TiferetError.
+    error = TiferetError('INVALID_INPUT', 'bad input')
+
+    # Assert TiferetAPIError is raised with the correct status code.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.handle_error(error)
+
+    assert exc_info.value.status_code == 400
+    mock_get_status_code_evt.execute.assert_called_once_with(error_code='INVALID_INPUT')
+
+
+# ** test: handle_error_non_tiferet_error_500
+def test_handle_error_non_tiferet_error_500(
+        context: OpenApiContext,
+        mock_errors: ErrorContext,
+    ) -> None:
+    '''
+    Test that handle_error returns 500 for non-Tiferet exceptions.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_errors: The mock error context.
+    :type mock_errors: ErrorContext
+    '''
+
+    # Configure ErrorContext.handle_error to return a formatted error dict.
+    mock_errors.handle_error.return_value = dict(
+        name='App Error',
+        message='An error occurred',
+        error_code='APP_ERROR',
+    )
+
+    # Create a generic exception.
+    error = RuntimeError('unexpected failure')
+
+    # Assert TiferetAPIError is raised with status code 500.
+    with pytest.raises(TiferetAPIError) as exc_info:
+        context.handle_error(error)
+
+    assert exc_info.value.status_code == 500
+
+
+# ** test: handle_response_returns_tuple
+def test_handle_response_returns_tuple(
+        context: OpenApiContext,
+        mock_get_route_evt: DomainEvent,
+    ) -> None:
+    '''
+    Test that handle_response returns (response, status_code) tuple.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_route_evt: The mock get_route domain event.
+    :type mock_get_route_evt: DomainEvent
+    '''
+
+    # Create a mock route with status_code.
+    mock_route = mock.Mock()
+    mock_route.status_code = 201
+    mock_get_route_evt.execute.return_value = mock_route
+
+    # Create a request and set a result.
+    request = context.parse_request(feature_id='calc.add')
+    request.result = {'sum': 3}
+
+    # Handle the response.
+    response, status_code = context.handle_response(request)
+
+    # Assert the response and status code.
+    assert response == {'sum': 3}
+    assert status_code == 201
+    mock_get_route_evt.execute.assert_called_once_with(endpoint='calc.add')
+
+
+# ** test: set_result_none
+def test_set_result_none() -> None:
+    '''
+    Test that set_result converts None to empty string.
+    '''
+
+    # Create a request context and set result to None.
+    request = OpenApiRequestContext(feature_id='test')
+    request.set_result(None)
+
+    # Assert the result is an empty string.
+    assert request.result == ''
+
+
+# ** test: set_result_base_model
+def test_set_result_base_model() -> None:
+    '''
+    Test that set_result serializes a Pydantic BaseModel to dict.
+    '''
+
+    # Create a request context and set result to a BaseModel.
+    request = OpenApiRequestContext(feature_id='test')
+    model = SampleModel(name='foo', value=42)
+    request.set_result(model)
+
+    # Assert the result is a dict.
+    assert request.result == {'name': 'foo', 'value': 42}
+
+
+# ** test: set_result_list_of_base_models
+def test_set_result_list_of_base_models() -> None:
+    '''
+    Test that set_result serializes a list of BaseModels to list of dicts.
+    '''
+
+    # Create a request context and set result to a list of BaseModels.
+    request = OpenApiRequestContext(feature_id='test')
+    models = [
+        SampleModel(name='a', value=1),
+        SampleModel(name='b', value=2),
+    ]
+    request.set_result(models)
+
+    # Assert the result is a list of dicts.
+    assert request.result == [
+        {'name': 'a', 'value': 1},
+        {'name': 'b', 'value': 2},
+    ]
+
+
+# ** test: set_result_dict_of_base_models
+def test_set_result_dict_of_base_models() -> None:
+    '''
+    Test that set_result serializes a dict of BaseModel values to dict of dicts.
+    '''
+
+    # Create a request context and set result to a dict of BaseModels.
+    request = OpenApiRequestContext(feature_id='test')
+    models = {
+        'x': SampleModel(name='x', value=10),
+        'y': SampleModel(name='y', value=20),
+    }
+    request.set_result(models)
+
+    # Assert the result is a dict of dicts.
+    assert request.result == {
+        'x': {'name': 'x', 'value': 10},
+        'y': {'name': 'y', 'value': 20},
+    }
+
+
+# ** test: set_result_primitive
+def test_set_result_primitive() -> None:
+    '''
+    Test that set_result passes primitive values through directly.
+    '''
+
+    # Create a request context and set result to a primitive.
+    request = OpenApiRequestContext(feature_id='test')
+    request.set_result(42)
+
+    # Assert the result is the primitive value.
+    assert request.result == 42
+
+
+# ** test: set_result_with_data_key
+def test_set_result_with_data_key() -> None:
+    '''
+    Test that set_result with data_key delegates to parent (stores in request.data).
+    '''
+
+    # Create a request context and set result with a data_key.
+    request = OpenApiRequestContext(feature_id='test', data={})
+    request.set_result('intermediate', data_key='step_result')
+
+    # Assert the value is stored in request.data.
+    assert request.data['step_result'] == 'intermediate'
+
+
+# ** test: handle_response_serializes_result
+def test_handle_response_serializes_result() -> None:
+    '''
+    Test that handle_response calls set_result before returning.
+    '''
+
+    # Create a request context with a BaseModel result.
+    request = OpenApiRequestContext(feature_id='test')
+    request.result = SampleModel(name='test', value=99)
+
+    # Handle the response.
+    response = request.handle_response()
+
+    # Assert the response is a serialized dict.
+    assert response == {'name': 'test', 'value': 99}


### PR DESCRIPTION
## Summary

Implements the shared context layer for tiferet-openapi, extracted from the identical FlaskApiContext/FastApiContext and FlaskRequestContext/FastRequestContext implementations.

### Changes
- **`tiferet_openapi/contexts/openapi.py`** — `OpenApiContext(AppInterfaceContext)` with domain event injection, `parse_request`, `handle_error` (status code resolution), and `handle_response` returning `(response, status_code)` tuple.
- **`tiferet_openapi/contexts/request.py`** — `OpenApiRequestContext(RequestContext)` with Pydantic-aware `set_result` (BaseModel, list/dict of BaseModel, None, primitives) and `handle_response`.
- **`tiferet_openapi/contexts/__init__.py`** — Public exports.
- **`tiferet_openapi/contexts/tests/test_openapi.py`** — 11 tests covering all acceptance criteria.

Closes #7

---
[Warp conversation](https://app.warp.dev/conversation/029e3b7e-e37e-4d09-8676-7e692cc2aa01)

Co-Authored-By: Oz <oz-agent@warp.dev>