### PR TITLE
Packaging, Exports, and Documentation (#8)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,101 @@
+name: Build and Publish tiferet-openapi
+
+on:
+  push:
+    tags:
+      - 'v*a*'     # alpha pre-releases: v0.1.0a1, v0.1.0a2, etc.
+      - 'v*b*'     # beta pre-releases: v0.1.0b1, v0.1.0b2, etc.
+  release:
+    types: [published]  # stable releases
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+
+      - name: Run tests
+        run: |
+          pytest --verbose
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      TIFERET_SILENT_IMPORTS: "1"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine setuptools>=42 wheel
+
+      - name: Extract version from tiferet_openapi/__init__.py
+        id: get_version
+        run: |
+          VERSION=$(python -c "from tiferet_openapi import __version__; print(__version__)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate version matches tag
+        run: |
+          TAG=${{ github.ref_name }}
+          PACKAGE_VERSION=${{ steps.get_version.outputs.version }}
+          if [ "$TAG" != "v$PACKAGE_VERSION" ]; then
+            echo "Error: Tag ($TAG) does not match package version (v$PACKAGE_VERSION)"
+            exit 1
+          fi
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Check package
+        run: |
+          twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-dist
+          path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: pypi
+
+    permissions:
+      id-token: write  # Required for OIDC authentication with PyPI
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md — Tiferet OpenAPI (v0.1.0)
+
+## Project Overview
+
+**Tiferet OpenAPI** is a shared OpenAPI abstraction layer for the Tiferet framework. It provides the common domain objects, service interfaces, domain events, mappers, YAML-backed repository, and context classes that both [tiferet-flask](https://github.com/greatstrength/tiferet-flask) and [tiferet-fast](https://github.com/greatstrength/tiferet-fast) depend on.
+
+- **Repository:** https://github.com/greatstrength/tiferet-openapi
+- **Branch:** `main`
+- **Python:** ≥ 3.10
+- **Version:** `0.1.0`
+- **Dependencies:** `tiferet >= 2.0.0b1`
+
+## Architecture
+
+### Package Layout
+
+```
+tiferet_openapi/
+├── __init__.py          — Version and public exports
+├── domain/              — ApiRoute, ApiRouter (DomainObject, Pydantic v2)
+├── interfaces/          — OpenApiService (Service ABC)
+├── events/              — GetRouters, GetRoute, GetStatusCode (DomainEvent)
+├── mappers/             — Aggregates and TransferObjects for YAML round-trip
+├── repos/               — OpenApiYamlRepository (YamlLoader-backed OpenApiService)
+└── contexts/            — OpenApiContext (AppInterfaceContext), OpenApiRequestContext
+```
+
+### Key Concepts
+
+- **Domain Objects** (`domain/openapi.py`): `ApiRoute` and `ApiRouter` — read-only Pydantic v2 domain models extending `DomainObject` with `Field` annotations. `ApiRoute` includes an `endpoint` field (format: `router_name.route_id`).
+- **Service Interface** (`interfaces/openapi.py`): `OpenApiService` — abstract contract for API configuration access (`get_routers`, `get_route`, `get_status_code`). Returns domain objects.
+- **Domain Events** (`events/openapi.py`): `GetRouters`, `GetRoute`, `GetStatusCode` — receive `OpenApiService` via constructor injection. `GetRoute` parses dotted endpoint strings (e.g., `calc.add`). `GetStatusCode` uses `@DomainEvent.parameters_required`.
+- **Mappers** (`mappers/openapi.py`): `ApiRouteAggregate`, `ApiRouterAggregate` (mutable, direct Pydantic constructors), `ApiRouteYamlObject`, `ApiRouterYamlObject` (serialization via `_ROLES` ClassVar, `model_validate`, `@classmethod from_model`). `ApiRouterYamlObject.routes` is a `Dict[str, ApiRouteYamlObject]` keyed by route ID; `map()` converts to a list with endpoint derivation.
+- **Repository** (`repos/openapi.py`): `OpenApiYamlRepository` — `YamlLoader`-backed implementation of `OpenApiService`. Constructor params: `openapi_yaml_file`, `root_key` (default `'openapi'`), `encoding`. The `root_key` enables compatibility with `flask.yml`, `fast.yml`, and unified `openapi.yml` formats.
+- **Contexts** (`contexts/openapi.py`, `contexts/request.py`): `OpenApiContext` — receives `DomainEvent` instances (`get_route_evt`, `get_status_code_evt`), wraps `.execute` internally. `handle_error` raises `TiferetAPIError` with `status_code`. `handle_response` returns `(response, status_code)` tuple. `OpenApiRequestContext` serializes Pydantic `BaseModel` results via `model_dump()`.
+
+### Runtime Flow (within a framework adapter)
+
+1. Framework adapter (e.g., `FlaskAppBuilder`) loads settings and service provider.
+2. `OpenApiContext` is instantiated with `DomainEvent` instances for route and status code lookup.
+3. On request, `context.run()` parses the request, executes the feature, and returns a response with status code.
+4. `handle_error` resolves HTTP status via `get_status_code_handler`, raises `TiferetAPIError` with `status_code`.
+5. `handle_response` retrieves the route via `get_route_handler` and returns `(response, route.status_code)`.
+
+## Structured Code Style
+
+All code follows tiferet v2 artifact comment conventions:
+
+- `# ***` — Top-level sections: `imports`, `exports`, `models`, `events`, `contexts`, `interfaces`, `mappers`, `repos`
+- `# **` — Mid-level: `core`, `infra`, `app` (for imports); `model: <name>`, `event: <name>`, etc.
+- `# *` — Low-level: `attribute: <name>`, `init`, `method: <name>`, `method: <name> (static)`
+
+**Spacing:** One empty line between major sections, after docstrings, and between code snippets within methods.
+
+**Docstrings:** RST format with `:param`, `:type`, `:return`, `:rtype`.
+
+See the [tiferet AGENTS.md](https://github.com/greatstrength/tiferet) for the full style guide.
+
+## Testing
+
+- **Framework:** `pytest`
+- **Test location:** Co-located in `<package>/tests/` directories.
+- **Run tests:** `pytest tiferet_openapi/ -v`
+- **Patterns:**
+  - Domain/mapper tests use direct Pydantic constructors and the harness-based `AggregateTestBase` / `TransferObjectTestBase`.
+  - Event tests use `DomainEvent.handle()` with mocked `OpenApiService`.
+  - Repo tests are integration tests using `tmp_path` with real temporary YAML files.
+  - Context tests use `mock.Mock(spec=DomainEvent)` for event dependencies.
+
+## Key Files
+
+- `tiferet_openapi/__init__.py` — Version (`__version__`) and public exports
+- `tiferet_openapi/domain/openapi.py` — `ApiRoute`, `ApiRouter` domain objects
+- `tiferet_openapi/interfaces/openapi.py` — `OpenApiService` interface
+- `tiferet_openapi/events/openapi.py` — `GetRouters`, `GetRoute`, `GetStatusCode` domain events
+- `tiferet_openapi/mappers/openapi.py` — Aggregates and TransferObjects
+- `tiferet_openapi/repos/openapi.py` — `OpenApiYamlRepository`
+- `tiferet_openapi/contexts/openapi.py` — `OpenApiContext`
+- `tiferet_openapi/contexts/request.py` — `OpenApiRequestContext`
+
+## YAML Configuration Format
+
+```yaml
+openapi:  # root_key — can be 'flask', 'fast', or any custom key
+  routers:
+    calc:
+      prefix: /calc
+      routes:
+        add:
+          path: /add
+          methods: [POST]
+          status_code: 200
+  errors:
+    INVALID_INPUT: 400
+    DIVISION_BY_ZERO: 422
+```
+
+## Public Exports
+
+```python
+from tiferet_openapi import (
+    # Domain
+    ApiRoute, ApiRouter,
+    # Interface
+    OpenApiService,
+    # Events
+    GetRouters, GetRoute, GetStatusCode,
+    # Mappers
+    ApiRouteAggregate, ApiRouterAggregate,
+    ApiRouteYamlObject, ApiRouterYamlObject,
+    # Repository
+    OpenApiYamlRepository,
+    # Contexts
+    OpenApiContext, OpenApiRequestContext,
+)
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,179 @@
-# tiferet-openapi
-A Tiferet Extension of the Open API Schematics 
+# Tiferet OpenAPI — A Shared OpenAPI Abstraction Layer for the Tiferet Framework
+
+## Introduction
+
+Tiferet OpenAPI provides the shared abstraction layer that both [tiferet-flask](https://github.com/greatstrength/tiferet-flask) and [tiferet-fast](https://github.com/greatstrength/tiferet-fast) depend on for OpenAPI-style API development. It extracts the common domain objects, service interfaces, domain events, mappers, YAML-backed repository, and context classes that were previously duplicated across both framework adapters.
+
+By unifying these components into a single package, tiferet-openapi eliminates code duplication, ensures behavioral consistency between Flask and FastAPI adapters, and provides a clean foundation for building new framework adapters.
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install tiferet-openapi
+```
+
+### For Development
+
+```bash
+git clone https://github.com/greatstrength/tiferet-openapi.git
+cd tiferet-openapi
+python3.10 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[test]"
+```
+
+## Architecture
+
+Tiferet OpenAPI follows the Tiferet framework's layered Domain-Driven Design architecture:
+
+```
+tiferet_openapi/
+├── __init__.py          — Version and public exports
+├── domain/              — ApiRoute, ApiRouter (DomainObject, Pydantic v2)
+├── interfaces/          — OpenApiService (Service ABC)
+├── events/              — GetRouters, GetRoute, GetStatusCode (DomainEvent)
+├── mappers/             — Aggregates and TransferObjects for YAML round-trip
+├── repos/               — OpenApiYamlRepository (YamlLoader-backed OpenApiService)
+└── contexts/            — OpenApiContext (AppInterfaceContext), OpenApiRequestContext
+```
+
+### Domain Objects
+
+`ApiRoute` and `ApiRouter` are read-only Pydantic v2 domain models that represent API routing configuration:
+
+- **`ApiRoute`** — An individual route with `id`, `endpoint` (format: `router_name.route_id`), `path`, `methods`, and `status_code`.
+- **`ApiRouter`** — A named group of routes with an optional URL `prefix`.
+
+### Service Interface
+
+`OpenApiService` is the abstract contract for API configuration access:
+
+- `get_routers()` — Retrieve all configured routers.
+- `get_route(route_id, router_name=None)` — Look up a single route.
+- `get_status_code(error_code)` — Map an error code to an HTTP status code.
+
+### Domain Events
+
+Three domain events encapsulate the service operations for use in the feature workflow:
+
+- **`GetRouters`** — Retrieves all routers via the injected `OpenApiService`.
+- **`GetRoute`** — Parses a dotted endpoint string (e.g., `calc.add`) and retrieves the matching route.
+- **`GetStatusCode`** — Looks up the HTTP status code for a given error code.
+
+### Mappers
+
+Aggregates and TransferObjects bridge YAML configuration and runtime domain objects:
+
+- **`ApiRouteAggregate`**, **`ApiRouterAggregate`** — Mutable aggregates with route management methods.
+- **`ApiRouteYamlObject`**, **`ApiRouterYamlObject`** — YAML serialization with `_ROLES`-based role control, `map()` for aggregate construction, `from_model()` for reverse mapping.
+
+### Repository
+
+`OpenApiYamlRepository` is the YAML-backed implementation of `OpenApiService`. It accepts a parameterized `root_key` (defaults to `"openapi"`) enabling compatibility with multiple YAML formats:
+
+- `root_key="openapi"` — unified `openapi.yml` format
+- `root_key="flask"` — legacy `flask.yml` format
+- `root_key="fast"` — legacy `fast.yml` format
+
+### Contexts
+
+- **`OpenApiContext(AppInterfaceContext)`** — Shared API context that receives `DomainEvent` instances for route and status code lookup. Provides `parse_request`, `handle_error` (with HTTP status code resolution), and `handle_response` (returning `(response, status_code)` tuples).
+- **`OpenApiRequestContext(RequestContext)`** — Pydantic-aware request context that serializes `BaseModel` results via `model_dump()`, with support for lists, dicts, `None`, and primitives.
+
+## YAML Configuration Format
+
+The repository reads configuration from a YAML file with the following structure:
+
+```yaml
+openapi:  # root_key (can be 'flask', 'fast', or any custom key)
+  routers:
+    calc:
+      prefix: /calc
+      routes:
+        add:
+          path: /add
+          methods:
+            - POST
+          status_code: 200
+        subtract:
+          path: /subtract
+          methods:
+            - POST
+          status_code: 200
+    health:
+      routes:
+        ping:
+          path: /ping
+          methods:
+            - GET
+          status_code: 200
+  errors:
+    INVALID_INPUT: 400
+    DIVISION_BY_ZERO: 422
+    NOT_FOUND: 404
+```
+
+## Usage
+
+Tiferet OpenAPI is consumed by framework-specific adapters. Here's how the shared components integrate:
+
+### In tiferet-flask / tiferet-fast
+
+Framework adapters extend `OpenApiContext` and use `OpenApiYamlRepository` as their configuration backend:
+
+```python
+# Framework adapter context (e.g., FlaskApiContext)
+from tiferet_openapi import OpenApiContext, OpenApiRequestContext
+
+class FlaskApiContext(OpenApiContext):
+    # Inherits parse_request, handle_error, handle_response
+    # Adds Flask-specific builder logic
+    pass
+```
+
+### Direct Repository Usage
+
+```python
+from tiferet_openapi import OpenApiYamlRepository
+
+# Load configuration
+repo = OpenApiYamlRepository(
+    openapi_yaml_file='app/configs/openapi.yml',
+    root_key='openapi',
+)
+
+# Retrieve all routers
+routers = repo.get_routers()
+for router in routers:
+    print(f"{router.name}: {router.prefix}")
+    for route in router.routes:
+        print(f"  {route.endpoint} -> {route.path} [{', '.join(route.methods)}]")
+
+# Look up a specific route
+route = repo.get_route('add', router_name='calc')
+print(f"Route: {route.endpoint}, Status: {route.status_code}")
+
+# Map error code to HTTP status
+status = repo.get_status_code('INVALID_INPUT')  # Returns 400
+status = repo.get_status_code('UNKNOWN')         # Returns 500 (default)
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+pytest tiferet_openapi/ -v
+```
+
+Tests are co-located in `<package>/tests/` directories:
+- **Domain/mapper tests** use direct Pydantic constructors.
+- **Event tests** use `DomainEvent.handle()` with mocked `OpenApiService`.
+- **Repo tests** are integration tests using `tmp_path` with real YAML files.
+- **Context tests** use `mock.Mock(spec=DomainEvent)` for event dependencies.
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "tiferet-openapi"
+dynamic = ["version"]  # Mark version as dynamic
+description = "A shared OpenAPI abstraction layer for the Tiferet Framework."
+authors = [
+    { name = "Andrew Shatz, Great Strength Systems", email = "andrew@greatstrength.me" }
+]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "tiferet>=2.0.0b1"
+]
+
+[project.urls]
+Homepage = "https://github.com/greatstrength/tiferet-openapi"
+Repository = "https://github.com/greatstrength/tiferet-openapi"
+Download = "https://github.com/greatstrength/tiferet-openapi"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3.3",
+    "pytest_env>=1.1.5"
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = [
+    "tiferet_openapi",
+    "tiferet_openapi.contexts",
+    "tiferet_openapi.domain",
+    "tiferet_openapi.events",
+    "tiferet_openapi.interfaces",
+    "tiferet_openapi.mappers",
+    "tiferet_openapi.repos"
+]
+
+[tool.setuptools.dynamic]
+version = { attr = "tiferet_openapi.__version__" }

--- a/tiferet_openapi/__init__.py
+++ b/tiferet_openapi/__init__.py
@@ -1,0 +1,26 @@
+# *** exports
+
+# ** app
+# Export the main domain objects, interfaces, events, mappers, repos, and contexts.
+# Use a try-except block to avoid import errors on build systems.
+try:
+    from .domain import ApiRoute, ApiRouter
+    from .interfaces import OpenApiService
+    from .events import GetRouters, GetRoute, GetStatusCode
+    from .mappers import (
+        ApiRouteAggregate,
+        ApiRouterAggregate,
+        ApiRouteYamlObject,
+        ApiRouterYamlObject,
+    )
+    from .repos import OpenApiYamlRepository
+    from .contexts import OpenApiContext, OpenApiRequestContext
+except Exception as e:
+    import os, sys
+    # Only print warning if TIFERET_SILENT_IMPORTS is not set to a truthy value
+    if not os.getenv('TIFERET_SILENT_IMPORTS'):
+        print(f"Warning: Failed to import Tiferet OpenAPI modules: {e}", file=sys.stderr)
+    pass
+
+# *** version
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary

Finalizes the tiferet-openapi package for its v0.1.0 initial release.

### Changes
- **`pyproject.toml`** — Package metadata with dynamic version, `tiferet>=2.0.0b1` dependency, setuptools config, and test optional dependencies.
- **`tiferet_openapi/__init__.py`** — Top-level exports for all public APIs with try-except pattern and `__version__ = "0.1.0"`.
- **`README.md`** — Comprehensive documentation: introduction, installation, architecture overview (all 6 layers), YAML configuration format, usage examples (adapter extension + direct repo usage), testing, and license.
- **`AGENTS.md`** — AI agent orientation: project overview, layer-by-layer architecture, key files, structured code style summary, testing conventions, YAML format, and public exports.
- **`.github/workflows/python-publish.yml`** — GitHub Actions workflow: alpha/beta tags trigger pre-release publish, release event triggers stable publish. Test → Build → Publish pipeline with version-tag validation.

### Validation
- `tiferet_openapi.__version__` returns `"0.1.0"` ✓
- All top-level imports work ✓
- All 37 tests pass ✓

Closes #8

---
[Warp conversation](https://app.warp.dev/conversation/029e3b7e-e37e-4d09-8676-7e692cc2aa01)

Co-Authored-By: Oz <oz-agent@warp.dev>