### PR TITLE
Domain – Add Swagger Metadata Fields and Request/Response Base Models (#18)

### DIFF
--- a/tiferet_openapi/__init__.py
+++ b/tiferet_openapi/__init__.py
@@ -4,7 +4,7 @@
 # Export the main domain objects, interfaces, events, mappers, repos, and contexts.
 # Use a try-except block to avoid import errors on build systems.
 try:
-    from .domain import ApiRoute, ApiRouter
+    from .domain import ApiRoute, ApiRouter, ApiRequestModel, ApiResponseModel, ApiErrorResponse
     from .interfaces import OpenApiService
     from .events import GetRouters, GetRoute, GetStatusCode
     from .mappers import (
@@ -23,4 +23,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/tiferet_openapi/domain/__init__.py
+++ b/tiferet_openapi/domain/__init__.py
@@ -4,3 +4,4 @@
 
 # ** app
 from .openapi import ApiRoute, ApiRouter
+from .request import ApiRequestModel, ApiResponseModel, ApiErrorResponse

--- a/tiferet_openapi/domain/openapi.py
+++ b/tiferet_openapi/domain/openapi.py
@@ -50,6 +50,36 @@ class ApiRoute(DomainObject):
         description='The default HTTP status code.',
     )
 
+    # * attribute: summary
+    summary: str | None = Field(
+        default=None,
+        description='Route summary for OpenAPI documentation.',
+    )
+
+    # * attribute: description
+    description: str | None = Field(
+        default=None,
+        description='Route description for OpenAPI documentation.',
+    )
+
+    # * attribute: tags
+    tags: List[str] = Field(
+        default_factory=list,
+        description='Tags for OpenAPI documentation grouping.',
+    )
+
+    # * attribute: request_model
+    request_model: str | None = Field(
+        default=None,
+        description='Dotted import path to the request Pydantic model class.',
+    )
+
+    # * attribute: response_model
+    response_model: str | None = Field(
+        default=None,
+        description='Dotted import path to the response Pydantic model class.',
+    )
+
 
 # ** model: api_router
 class ApiRouter(DomainObject):

--- a/tiferet_openapi/domain/request.py
+++ b/tiferet_openapi/domain/request.py
@@ -1,0 +1,55 @@
+'''Tiferet OpenAPI Request/Response Domain Objects'''
+
+# *** imports
+
+# ** infra
+from pydantic import Field
+
+# ** app
+from tiferet import DomainObject
+
+
+# *** models
+
+# ** model: api_request_model
+class ApiRequestModel(DomainObject):
+    '''
+    Base request model for OpenAPI documentation.
+
+    Application-level request models extend this class to define
+    route-specific input schemas. Since DomainObject extends
+    pydantic.BaseModel, these models integrate with FastAPI's
+    native Pydantic model support for automatic Swagger schema
+    generation.
+    '''
+    pass
+
+
+# ** model: api_response_model
+class ApiResponseModel(DomainObject):
+    '''
+    Base response model for OpenAPI documentation.
+
+    Application-level response models extend this class to define
+    route-specific output schemas.
+    '''
+    pass
+
+
+# ** model: api_error_response
+class ApiErrorResponse(DomainObject):
+    '''
+    Standard error response model for OpenAPI error documentation.
+    '''
+
+    # * attribute: error
+    error: str = Field(
+        ...,
+        description='The error name.',
+    )
+
+    # * attribute: message
+    message: str = Field(
+        ...,
+        description='The error message.',
+    )

--- a/tiferet_openapi/domain/tests/test_openapi.py
+++ b/tiferet_openapi/domain/tests/test_openapi.py
@@ -137,6 +137,56 @@ def test_api_router_prefix_default() -> None:
     assert router.prefix is None
 
 
+# ** test: api_route_swagger_fields
+def test_api_route_swagger_fields() -> None:
+    '''
+    Test that ApiRoute accepts all 5 optional Swagger metadata fields.
+    '''
+
+    # Create a route with all Swagger metadata fields.
+    route = ApiRoute(
+        id='add',
+        endpoint='calc.add',
+        path='/add',
+        methods=['POST'],
+        status_code=200,
+        summary='Add two numbers',
+        description='Adds two numbers and returns the result',
+        tags=['calculator', 'arithmetic'],
+        request_model='app.domain.request.AddNumberRequest',
+        response_model='app.domain.request.CalculatorResponse',
+    )
+
+    # Verify all Swagger metadata fields.
+    assert route.summary == 'Add two numbers'
+    assert route.description == 'Adds two numbers and returns the result'
+    assert route.tags == ['calculator', 'arithmetic']
+    assert route.request_model == 'app.domain.request.AddNumberRequest'
+    assert route.response_model == 'app.domain.request.CalculatorResponse'
+
+
+# ** test: api_route_swagger_fields_defaults
+def test_api_route_swagger_fields_defaults() -> None:
+    '''
+    Test that new Swagger metadata fields default correctly when not provided.
+    '''
+
+    # Create a route without Swagger metadata fields.
+    route = ApiRoute(
+        id='get_users',
+        endpoint='users.get_users',
+        path='/users',
+        methods=['GET'],
+    )
+
+    # Verify defaults.
+    assert route.summary is None
+    assert route.description is None
+    assert route.tags == []
+    assert route.request_model is None
+    assert route.response_model is None
+
+
 # ** test: api_router_routes_default
 def test_api_router_routes_default() -> None:
     '''

--- a/tiferet_openapi/domain/tests/test_request.py
+++ b/tiferet_openapi/domain/tests/test_request.py
@@ -1,0 +1,122 @@
+'''Tiferet OpenAPI Request/Response Domain Object Tests'''
+
+# *** imports
+
+# ** infra
+import pytest
+from pydantic import Field, ValidationError
+
+# ** app
+from ..request import ApiRequestModel, ApiResponseModel, ApiErrorResponse
+
+
+# *** tests
+
+# ** test: api_request_model_extensible
+def test_api_request_model_extensible() -> None:
+    '''
+    Test that ApiRequestModel can be extended with custom fields.
+    '''
+
+    # Define a custom request model.
+    class AddNumberRequest(ApiRequestModel):
+        '''Custom request model for addition.'''
+        a: float = Field(..., description='First operand.')
+        b: float = Field(..., description='Second operand.')
+
+    # Instantiate the custom request model.
+    request = AddNumberRequest(a=1.5, b=2.5)
+
+    # Verify the fields.
+    assert request.a == 1.5
+    assert request.b == 2.5
+
+
+# ** test: api_request_model_forbids_extra
+def test_api_request_model_forbids_extra() -> None:
+    '''
+    Test that ApiRequestModel rejects unknown fields (extra='forbid').
+    '''
+
+    # Define a custom request model.
+    class SimpleRequest(ApiRequestModel):
+        '''A simple request model.'''
+        name: str = Field(..., description='A name.')
+
+    # Attempt to instantiate with an extra field.
+    with pytest.raises(ValidationError):
+        SimpleRequest(name='test', unknown_field='bad')
+
+
+# ** test: api_response_model_extensible
+def test_api_response_model_extensible() -> None:
+    '''
+    Test that ApiResponseModel can be extended with custom fields.
+    '''
+
+    # Define a custom response model.
+    class CalculatorResponse(ApiResponseModel):
+        '''Custom response model for calculator results.'''
+        result: float = Field(..., description='The computed result.')
+        operation: str = Field(..., description='The operation performed.')
+
+    # Instantiate the custom response model.
+    response = CalculatorResponse(result=4.0, operation='add')
+
+    # Verify the fields.
+    assert response.result == 4.0
+    assert response.operation == 'add'
+
+
+# ** test: api_error_response_constructor
+def test_api_error_response_constructor() -> None:
+    '''
+    Test that ApiErrorResponse can be instantiated with error and message fields.
+    '''
+
+    # Create an error response.
+    error = ApiErrorResponse(
+        error='Invalid Input',
+        message='Value must be a number',
+    )
+
+    # Verify the fields.
+    assert error.error == 'Invalid Input'
+    assert error.message == 'Value must be a number'
+
+
+# ** test: api_error_response_requires_fields
+def test_api_error_response_requires_fields() -> None:
+    '''
+    Test that ApiErrorResponse requires both error and message fields.
+    '''
+
+    # Attempt to instantiate without required fields.
+    with pytest.raises(ValidationError):
+        ApiErrorResponse()
+
+
+# ** test: api_request_model_empty
+def test_api_request_model_empty() -> None:
+    '''
+    Test that base ApiRequestModel can be instantiated without fields.
+    '''
+
+    # Instantiate the base request model.
+    request = ApiRequestModel()
+
+    # Verify it is an instance.
+    assert isinstance(request, ApiRequestModel)
+
+
+# ** test: api_response_model_empty
+def test_api_response_model_empty() -> None:
+    '''
+    Test that base ApiResponseModel can be instantiated without fields.
+    '''
+
+    # Instantiate the base response model.
+    response = ApiResponseModel()
+
+    # Verify it is an instance.
+    assert isinstance(response, ApiResponseModel)

--- a/tiferet_openapi/mappers/openapi.py
+++ b/tiferet_openapi/mappers/openapi.py
@@ -94,7 +94,7 @@ class ApiRouteYamlObject(ApiRoute, TransferObject):
         'to_model': {},
         'to_data.yaml': {
             'by_alias': True,
-            'exclude': {'id', 'endpoint'},
+            'exclude': {'id', 'endpoint', 'tags'},
         },
     }
 

--- a/tiferet_openapi/mappers/tests/test_openapi.py
+++ b/tiferet_openapi/mappers/tests/test_openapi.py
@@ -220,3 +220,81 @@ def test_api_router_from_model_round_trip() -> None:
     assert result.routes[0].id == 'get_users'
     assert result.routes[0].endpoint == 'users.get_users'
     assert result.routes[0].path == '/users'
+
+
+# ** test: api_route_yaml_object_map_with_swagger_fields
+def test_api_route_yaml_object_map_with_swagger_fields() -> None:
+    '''
+    Test that ApiRouteYamlObject.map() preserves Swagger metadata fields.
+    '''
+
+    # Create a route YAML object with Swagger metadata fields.
+    yaml_data = dict(
+        path='/add',
+        methods=['POST'],
+        status_code=200,
+        summary='Add two numbers',
+        description='Adds two numbers and returns the result',
+        tags=['calculator', 'arithmetic'],
+        request_model='app.domain.request.AddNumberRequest',
+        response_model='app.domain.request.CalculatorResponse',
+    )
+    yaml_obj = ApiRouteYamlObject.model_validate(yaml_data)
+    aggregate = yaml_obj.map(id='add', endpoint='calc.add')
+
+    # Verify Swagger metadata fields are preserved.
+    assert aggregate.summary == 'Add two numbers'
+    assert aggregate.description == 'Adds two numbers and returns the result'
+    assert aggregate.tags == ['calculator', 'arithmetic']
+    assert aggregate.request_model == 'app.domain.request.AddNumberRequest'
+    assert aggregate.response_model == 'app.domain.request.CalculatorResponse'
+
+
+# ** test: api_route_swagger_fields_round_trip
+def test_api_route_swagger_fields_round_trip() -> None:
+    '''
+    Test that from_model round-trips correctly for ApiRoute with Swagger metadata fields.
+    '''
+
+    # Create a route aggregate with Swagger metadata fields.
+    aggregate = ApiRouteAggregate(
+        id='add',
+        endpoint='calc.add',
+        path='/add',
+        methods=['POST'],
+        status_code=200,
+        summary='Add two numbers',
+        description='Adds two numbers and returns the result',
+        tags=['calculator', 'arithmetic'],
+        request_model='app.domain.request.AddNumberRequest',
+        response_model='app.domain.request.CalculatorResponse',
+    )
+
+    # Convert to YAML object and back.
+    yaml_obj = ApiRouteYamlObject.from_model(aggregate)
+    result = yaml_obj.map()
+
+    # Verify round-trip preserves Swagger metadata.
+    assert result.summary == aggregate.summary
+    assert result.description == aggregate.description
+    assert result.tags == aggregate.tags
+    assert result.request_model == aggregate.request_model
+    assert result.response_model == aggregate.response_model
+
+
+# ** test: api_route_yaml_object_map_without_swagger_fields
+def test_api_route_yaml_object_map_without_swagger_fields() -> None:
+    '''
+    Test that ApiRouteYamlObject.map() works without Swagger metadata (backward compat).
+    '''
+
+    # Create a route YAML object without Swagger metadata.
+    yaml_obj = ApiRouteYamlObject.model_validate(ROUTE_YAML_DATA)
+    aggregate = yaml_obj.map(id='get_users', endpoint='users.get_users')
+
+    # Verify defaults for Swagger metadata fields.
+    assert aggregate.summary is None
+    assert aggregate.description is None
+    assert aggregate.tags == []
+    assert aggregate.request_model is None
+    assert aggregate.response_model is None


### PR DESCRIPTION
## Summary

Extends the tiferet-openapi domain layer with Swagger/OpenAPI documentation support:

1. **Swagger metadata fields on `ApiRoute`** — optional `summary`, `description`, `tags`, `request_model`, and `response_model` fields for richer OpenAPI specs in both Flask and FastAPI adapters.
2. **Base request/response domain objects** (`domain/request.py`) — `ApiRequestModel`, `ApiResponseModel`, and `ApiErrorResponse` base classes extending `DomainObject` for route-specific input/output schemas.

## Changes

- **`domain/openapi.py`**: Added 5 optional fields to `ApiRoute` (all backward compatible with safe defaults)
- **`domain/request.py`**: New file with `ApiRequestModel`, `ApiResponseModel`, `ApiErrorResponse`
- **`mappers/openapi.py`**: Updated `ApiRouteYamlObject._ROLES` to exclude `tags` from `to_data.yaml`
- **`domain/__init__.py`** and **`__init__.py`**: Updated exports, bumped version to `0.1.2`
- **Tests**: 12 new tests covering Swagger metadata fields, round-trips, backward compatibility, and request/response models (54 total, all passing)

Closes #18

---
[Warp conversation](https://app.warp.dev/conversation/ed9c489d-edf4-41e1-bd86-03a656df9898)

Co-Authored-By: Oz <oz-agent@warp.dev>