### PR TITLE
Bump tiferet dependency to v2.0.0b3 (#20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Tiferet OpenAPI (v0.1.0)
+# AGENTS.md — Tiferet OpenAPI (v0.1.3)
 
 ## Project Overview
 
@@ -7,8 +7,8 @@
 - **Repository:** https://github.com/greatstrength/tiferet-openapi
 - **Branch:** `main`
 - **Python:** ≥ 3.10
-- **Version:** `0.1.0`
-- **Dependencies:** `tiferet >= 2.0.0b1`
+- **Version:** `0.1.3`
+- **Dependencies:** `tiferet >= 2.0.0b3`
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "tiferet>=2.0.0b1"
+    "tiferet>=2.0.0b3"
 ]
 
 [project.urls]

--- a/tiferet_openapi/__init__.py
+++ b/tiferet_openapi/__init__.py
@@ -23,4 +23,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Summary

Bump the `tiferet` dependency from `>=2.0.0b1` to `>=2.0.0b3` and update the package version from `0.1.2` to `0.1.3`.

### Changes
- `pyproject.toml`: dependency specifier `tiferet>=2.0.0b1` → `tiferet>=2.0.0b3`
- `tiferet_openapi/__init__.py`: version `0.1.2` → `0.1.3`
- `AGENTS.md`: version and dependency references updated

### Impact Analysis
All tiferet imports used by tiferet-openapi are stable across b1→b3. The breaking changes in b2 (DI backend migration) and b3 (builders→blueprints) do not affect any tiferet-openapi code. Full test suite (54 tests) passes with zero failures.

Closes #20

---
[Conversation](https://app.warp.dev/conversation/4630254d-6eff-43a8-97d4-4e16c8222c15) | [TRD](https://app.warp.dev/drive/notebook/nnw2CvK6FDE3zHCn1ajLBZ)

Co-Authored-By: Oz <oz-agent@warp.dev>