### PR TITLE
v1.0.0b1: OpenAPI spec generation with full doc fields and model schemas

### DIFF
--- a/tiferet_openapi/__init__.py
+++ b/tiferet_openapi/__init__.py
@@ -23,4 +23,4 @@ except Exception as e:
     pass
 
 # *** version
-__version__ = "0.1.3"
+__version__ = "1.0.0b1"

--- a/tiferet_openapi/contexts/openapi.py
+++ b/tiferet_openapi/contexts/openapi.py
@@ -3,6 +3,7 @@
 # *** imports
 
 # ** core
+import importlib
 from typing import Any, Callable
 
 # ** infra
@@ -146,6 +147,30 @@ class OpenApiContext(AppInterfaceContext):
         # Return the result with the specified status code.
         return response, route.status_code if route else 200
 
+    # * method: _resolve_model_schema
+    def _resolve_model_schema(self, model_path: str) -> dict | None:
+        '''
+        Resolve a dotted import path to a Pydantic model JSON schema.
+
+        :param model_path: Dotted import path (e.g. 'app.domain.request.AddRequest').
+        :type model_path: str
+        :return: The JSON schema dict, or None if resolution fails.
+        :rtype: dict | None
+        '''
+
+        try:
+            # Split the dotted path into module and class name.
+            module_path, class_name = model_path.rsplit('.', 1)
+
+            # Import the module and retrieve the class.
+            module = importlib.import_module(module_path)
+            model_cls = getattr(module, class_name)
+
+            # Return the JSON schema from the Pydantic model.
+            return model_cls.model_json_schema()
+        except Exception:
+            return None
+
     # * method: generate_spec
     def generate_spec(self, title: str = 'API', version: str = '1.0.0', description: str = '') -> dict:
         '''
@@ -172,7 +197,9 @@ class OpenApiContext(AppInterfaceContext):
                 if full_path not in paths:
                     paths[full_path] = {}
                 for method in route.methods:
-                    paths[full_path][method.lower()] = {
+
+                    # Build the base operation entry.
+                    operation = {
                         'operationId': route.endpoint,
                         'responses': {
                             str(route.status_code): {
@@ -180,6 +207,44 @@ class OpenApiContext(AppInterfaceContext):
                             },
                         },
                     }
+
+                    # Include summary if present.
+                    if route.summary:
+                        operation['summary'] = route.summary
+
+                    # Include description if present.
+                    if route.description:
+                        operation['description'] = route.description
+
+                    # Include tags if present.
+                    if route.tags:
+                        operation['tags'] = route.tags
+
+                    # Resolve request model schema for requestBody if present.
+                    if route.request_model:
+                        request_schema = self._resolve_model_schema(route.request_model)
+                        if request_schema:
+                            operation['requestBody'] = {
+                                'required': True,
+                                'content': {
+                                    'application/json': {
+                                        'schema': request_schema,
+                                    },
+                                },
+                            }
+
+                    # Resolve response model schema if present.
+                    if route.response_model:
+                        response_schema = self._resolve_model_schema(route.response_model)
+                        if response_schema:
+                            operation['responses'][str(route.status_code)]['content'] = {
+                                'application/json': {
+                                    'schema': response_schema,
+                                },
+                            }
+
+                    # Add the operation to the path.
+                    paths[full_path][method.lower()] = operation
 
         # Return the OpenAPI 3.0 spec.
         return {

--- a/tiferet_openapi/contexts/tests/test_openapi.py
+++ b/tiferet_openapi/contexts/tests/test_openapi.py
@@ -540,6 +540,184 @@ def test_generate_spec_multiple_methods(
     assert spec['paths']['/api/item']['post']['operationId'] == 'items.item'
 
 
+# ** test: generate_spec_with_doc_fields
+def test_generate_spec_with_doc_fields(
+        context: OpenApiContext,
+        mock_get_routers_evt: DomainEvent,
+    ) -> None:
+    '''
+    Test that generate_spec includes summary, description, and tags from routes.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_routers_evt: The mock get_routers domain event.
+    :type mock_get_routers_evt: DomainEvent
+    '''
+
+    # Configure mock routers with doc fields.
+    mock_get_routers_evt.execute.return_value = [
+        ApiRouter(
+            name='calc',
+            prefix='/calc',
+            routes=[
+                ApiRoute(
+                    id='add',
+                    endpoint='calc.add',
+                    path='/add',
+                    methods=['POST'],
+                    status_code=200,
+                    summary='Add two numbers',
+                    description='Adds two numbers and returns the result.',
+                    tags=['Calculator', 'Arithmetic'],
+                ),
+            ],
+        ),
+    ]
+
+    # Generate the spec.
+    spec = context.generate_spec()
+
+    # Assert the doc fields are present in the operation.
+    operation = spec['paths']['/calc/add']['post']
+    assert operation['summary'] == 'Add two numbers'
+    assert operation['description'] == 'Adds two numbers and returns the result.'
+    assert operation['tags'] == ['Calculator', 'Arithmetic']
+
+
+# ** test: generate_spec_without_doc_fields
+def test_generate_spec_without_doc_fields(
+        context: OpenApiContext,
+        mock_get_routers_evt: DomainEvent,
+    ) -> None:
+    '''
+    Test that generate_spec omits summary, description, and tags when not set.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_routers_evt: The mock get_routers domain event.
+    :type mock_get_routers_evt: DomainEvent
+    '''
+
+    # Configure mock routers without doc fields.
+    mock_get_routers_evt.execute.return_value = [
+        ApiRouter(
+            name='calc',
+            prefix='/calc',
+            routes=[
+                ApiRoute(id='add', endpoint='calc.add', path='/add', methods=['POST'], status_code=200),
+            ],
+        ),
+    ]
+
+    # Generate the spec.
+    spec = context.generate_spec()
+
+    # Assert the doc fields are absent from the operation.
+    operation = spec['paths']['/calc/add']['post']
+    assert 'summary' not in operation
+    assert 'description' not in operation
+    assert 'tags' not in operation
+
+
+# ** test: generate_spec_with_request_response_models
+def test_generate_spec_with_request_response_models(
+        context: OpenApiContext,
+        mock_get_routers_evt: DomainEvent,
+    ) -> None:
+    '''
+    Test that generate_spec resolves request and response model schemas.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_routers_evt: The mock get_routers domain event.
+    :type mock_get_routers_evt: DomainEvent
+    '''
+
+    # Use the SampleModel defined in this test module as the model path.
+    model_path = f'{SampleModel.__module__}.{SampleModel.__qualname__}'
+
+    # Configure mock routers with request and response model paths.
+    mock_get_routers_evt.execute.return_value = [
+        ApiRouter(
+            name='calc',
+            prefix='/calc',
+            routes=[
+                ApiRoute(
+                    id='add',
+                    endpoint='calc.add',
+                    path='/add',
+                    methods=['POST'],
+                    status_code=200,
+                    request_model=model_path,
+                    response_model=model_path,
+                ),
+            ],
+        ),
+    ]
+
+    # Generate the spec.
+    spec = context.generate_spec()
+
+    # Assert requestBody schema is present.
+    operation = spec['paths']['/calc/add']['post']
+    assert 'requestBody' in operation
+    assert operation['requestBody']['required'] is True
+    request_schema = operation['requestBody']['content']['application/json']['schema']
+    assert 'properties' in request_schema
+    assert 'name' in request_schema['properties']
+    assert 'value' in request_schema['properties']
+
+    # Assert response schema is present.
+    response_content = operation['responses']['200'].get('content')
+    assert response_content is not None
+    response_schema = response_content['application/json']['schema']
+    assert 'properties' in response_schema
+    assert 'name' in response_schema['properties']
+    assert 'value' in response_schema['properties']
+
+
+# ** test: generate_spec_unresolvable_model_graceful
+def test_generate_spec_unresolvable_model_graceful(
+        context: OpenApiContext,
+        mock_get_routers_evt: DomainEvent,
+    ) -> None:
+    '''
+    Test that generate_spec gracefully handles unresolvable model paths.
+
+    :param context: The OpenApiContext instance.
+    :type context: OpenApiContext
+    :param mock_get_routers_evt: The mock get_routers domain event.
+    :type mock_get_routers_evt: DomainEvent
+    '''
+
+    # Configure mock routers with bad model paths.
+    mock_get_routers_evt.execute.return_value = [
+        ApiRouter(
+            name='calc',
+            prefix='/calc',
+            routes=[
+                ApiRoute(
+                    id='add',
+                    endpoint='calc.add',
+                    path='/add',
+                    methods=['POST'],
+                    status_code=200,
+                    request_model='nonexistent.module.FakeModel',
+                    response_model='nonexistent.module.FakeModel',
+                ),
+            ],
+        ),
+    ]
+
+    # Generate the spec — should not raise.
+    spec = context.generate_spec()
+
+    # Assert requestBody and response content are absent (graceful fallback).
+    operation = spec['paths']['/calc/add']['post']
+    assert 'requestBody' not in operation
+    assert 'content' not in operation['responses']['200']
+
+
 # ** test: create_docs_handler_returns_none
 def test_create_docs_handler_returns_none(context: OpenApiContext) -> None:
     '''

--- a/tiferet_openapi/mappers/openapi.py
+++ b/tiferet_openapi/mappers/openapi.py
@@ -94,7 +94,7 @@ class ApiRouteYamlObject(ApiRoute, TransferObject):
         'to_model': {},
         'to_data.yaml': {
             'by_alias': True,
-            'exclude': {'id', 'endpoint', 'tags'},
+            'exclude': {'id', 'endpoint'},
         },
     }
 


### PR DESCRIPTION
## Summary

Fix `generate_spec` to include route documentation metadata and Pydantic model schemas in the generated OpenAPI 3.0 specification.

### Changes
- **`contexts/openapi.py`**: Add `_resolve_model_schema` helper for dynamic Pydantic model JSON schema resolution. Update `generate_spec` to include `summary`, `description`, `tags`, `requestBody` (from `request_model`), and response content schema (from `response_model`) per route. Unresolvable model paths are handled gracefully.
- **`mappers/openapi.py`**: Remove `tags` from the `to_data.yaml` exclusion set so tags persist through YAML round-trips.
- **`contexts/tests/test_openapi.py`**: Add 4 new tests covering doc fields present/absent, request/response model schema resolution, and graceful fallback for bad model paths.
- **`__init__.py`**: Bump version to `1.0.0b1`.

### Testing
All 58 tests pass.

---
[Conversation](https://app.warp.dev/conversation/b15bd953-5961-42cf-8153-6899ebd6b32c)

Co-Authored-By: Oz <oz-agent@warp.dev>